### PR TITLE
Fixed pubsub reset and pg online test

### DIFF
--- a/lib/Minion/Notifier.pm
+++ b/lib/Minion/Notifier.pm
@@ -2,7 +2,7 @@ package Minion::Notifier;
 
 use Mojo::Base 'Mojo::EventEmitter';
 
-our $VERSION = '0.06';
+our $VERSION = '0.07';
 $VERSION = eval $VERSION;
 
 has minion => sub { die 'A Minion instance is required' };

--- a/lib/Minion/Notifier/Transport/Pg.pm
+++ b/lib/Minion/Notifier/Transport/Pg.pm
@@ -28,9 +28,9 @@ sub send {
 
 sub _start {
   my $self = shift;
-  # The pubsub object needs to be refreshed.
-  # Currently this is the best way to do that.
-  $self->pg->pubsub->unlisten($self->channel . '_dummy');
+  # The pubsub object needs to be refreshed or else we'll get
+  # zombies pretty quickly
+  $self->pg->pubsub->reset;
 }
 
 1;

--- a/t/pg.t
+++ b/t/pg.t
@@ -7,7 +7,7 @@ plan skip_all => 'set TEST_ONLINE_PG to a postgresql url to run test'
   unless my $url = $ENV{TEST_ONLINE_PG};
 
 use Test::Mojo;
-my $t = Test::Mojo->new;
+use Mojo::IOLoop;
 
 require Mojo::Pg;
 
@@ -45,6 +45,7 @@ any '/live' => sub {
   $id = $minion->enqueue('live');
 };
 
+my $t = Test::Mojo->new;
 $t->get_ok('/live')
   ->status_is(200)
   ->json_is('/id' => $id);


### PR DESCRIPTION
Hey, thank you so much for this Distribution!
Maybe things got sticky with the passage of time, but the pg online test wasn't running, so I fixed that, and I updated the _start method in the Pg transport to use 'reset', which resets the connection, preventing the child from stealing connections (and becoming a zombie).
I incremented $VERSION so you can get this on CPAN right away.